### PR TITLE
feat: ignore \\text command

### DIFF
--- a/lib/converters/latex-to-ast.js
+++ b/lib/converters/latex-to-ast.js
@@ -143,7 +143,7 @@ import flatten from './flatten';
 
 
 // Some of the latex commands that lead to spacing
-const whitespace_rule = '\\s|\\\\,|\\\\!|\\\\ |\\\\>|\\\\;|\\\\:|\\\\quad\\b|\\\\qquad\\b';
+const whitespace_rule = '\\s|\\\\,|\\\\!|\\\\ |\\\\>|\\\\;|\\\\:|\\\\quad\\b|\\\\qquad\\b|\\\\text{.*?}';
 
 const latex_rules = [
   ['[0-9]+(\\.[0-9]*)?(E[+\\-]?[0-9]+)?', 'NUMBER'],

--- a/spec/quick_latex-to-ast.spec.js
+++ b/spec/quick_latex-to-ast.spec.js
@@ -4,8 +4,9 @@ import { ParseError } from '../lib/converters/error';
 var converter = new latexToAst();
 
 var trees = {
-  
+  '1 * 3\\text{eggs}' : ['*', 1, 3], 
   '\\frac{1}{2} x': ['*',['/',1,2],'x'],
+  '\\frac{1}{2\\text{foo}} x': ['*',['/',1,2],'x'],
   '1+x+3': ['+',1,'x',3],
   '1-x-3': ['+',1,['-','x'],['-',3]],
   "1 + - x": ['+',1,['-','x']],


### PR DESCRIPTION
We have LaTex that intersperses text into mathematical expressions. We
want to be able to parse the LaTeX to math and just ignore thes
commands. This commit adds text as a whitespace rule.

I'm new to this lib so this may be a fairly naive approach - happy for feedback.